### PR TITLE
refactor: convert function to esm

### DIFF
--- a/functions/uuid/index.js
+++ b/functions/uuid/index.js
@@ -1,9 +1,0 @@
-const uuid = require('uuid');
-
-exports.handler = async () => ({
-  statusCode: 200,
-  headers: {
-    'Content-Type': 'text/plain; charset=UTF-8',
-  },
-  body: uuid.v4(),
-});

--- a/functions/uuid/index.mjs
+++ b/functions/uuid/index.mjs
@@ -1,0 +1,13 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export default async () => ({
+  statusCode: 200,
+  headers: {
+    'Content-Type': 'text/plain; charset=UTF-8',
+  },
+  body: uuidv4(),
+});
+
+export const config = {
+  path: ['/api/uuid'],
+};

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,6 @@
   functions  = "functions"
   publish = "public"
 
-[[redirects]]
-  from = "/api/*"
-  to = "/.netlify/functions/:splat"
-  status = 200
-
 [[headers]]
   for = "/*"
 


### PR DESCRIPTION
Convert the commonjs function to esm as recommended by Netlify.

Also add the route (path) to the config export of the function instead of hiding it away in netlify.toml