### PR TITLE
build: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,15 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "00:00"
+      timezone: "Etc/UTC"


### PR DESCRIPTION
- Add github-actions ecosystem
- Use "production" and "development" groups for the npm ecosystem