### PR TITLE
build: pin github actions using hashes

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -5,13 +5,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
-      - uses: pnpm/action-setup@v4.0.0
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version-file: .node-version
           cache: pnpm
-      - name: Check code style
-        run: |
-          pnpm install
-          pnpm lint
+      - run: pnpm install
+      - run: pnpm run lint


### PR DESCRIPTION
Tags can be removed and added to other commits, so use commit hashes instead.

These are picked up by Dependabot as well.