### PR TITLE
build: rename dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
       time: "00:00"
       timezone: "Etc/UTC"
     groups:
-      production:
+      dependencies:
         dependency-type: "production"
-      development:
+      devDependencies:
         dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
“development” in a pull request was unclear so change the group names to the of dependency-type that they represent.

“build(deps-dev): bump the devDependencies group with n updates”

instead of:

“build(deps-dev): bump the development group with n updates”