### PR TITLE
build: prettier config

### DIFF
--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,10 +1,11 @@
 export default {
   singleQuote: true,
-  trailingComma: 'es5',
   overrides: [
     {
       files: ['*.yml', '*.yaml'],
-      options: { singleQuote: false },
+      options: {
+        singleQuote: false,
+      },
     },
   ],
 };


### PR DESCRIPTION
Remove `trailingComma: 'es5'` in favour of the default `trailingComma: 'all` in Prettier 3.0
Use a new line for options