### PR TITLE
build: allow manual workflow runs

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,5 +1,7 @@
 name: NodeJS CI
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
Add `workflow_dispatch` to allow triggering workflow runs from the GitHub UI.