### PR TITLE
fix: workflow

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,14 +1,13 @@
 name: NodeJS CI
+
+on: pull_request
+
 permissions:
   contents: read
 
-on:
-  - pull_request
-  - workflow_dispatch
-
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
Re-order trigger and permissions.

Set concurrency.cancel-in-progress to true always, this would never be for the `refs/heads/main` ref.