### PR TITLE
chore: remove cache input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: .node-version
-          cache: pnpm
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run prettier


### PR DESCRIPTION
actions/setup-node detecs the cache automatically as of v5.0.0