### PR TITLE
ci: setup-node cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
+          cache: pnpm
           node-version-file: .node-version
       - run: pnpm install
       - run: pnpm run lint


### PR DESCRIPTION
Re-add the cache input to enable caching in preparation for updating to actions/setup-node@v6 where automatic cache only works for npm.