### PR TITLE
chore: add cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: 'saturday'
       time: '00:00'
       timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 5
     groups:
       # group all patch and minor version updates in one pull request
       minor-dependencies:
@@ -26,3 +28,5 @@ updates:
       day: 'saturday'
       time: '00:00'
       timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,14 +2,13 @@ packages:
   - functions/*
 
 ignoredBuiltDependencies:
-  - unix-dgram
-
-onlyBuiltDependencies:
   - '@parcel/watcher'
   - esbuild
   - netlify-cli
-  - oxc-resolver
   - sharp
+  - unix-dgram
+
+minimumReleaseAge: 7200
 
 saveExact: true
 


### PR DESCRIPTION
Both pnpm and dependabot now support cooldowns when installing dependencies.

- Set pnpm's minimumReleaseAge to 5 days (7200 minutes)
- Set dependabot's cooldown.default-days to 5 days