### PR TITLE
chore: remove overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  node-forge: ^1.3.2
   jws: ^3.2.3
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,6 @@ minimumReleaseAgeExclude:
   - jws
 
 overrides:
-  node-forge: ^1.3.2
   jws: ^3.2.3
 
 saveExact: true


### PR DESCRIPTION
The correct version of node-forge is now automatically installed so the override can be removed.