### PR TITLE
chore: increase npm registry cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       # Run every Saturday at 00:00.
       cronjob: '0 0 * * 6'
     cooldown:
-      default-days: 5
+      default-days: 7
     groups:
       # Group patch and minor version updates in a single pull request.
       patch-and-minor:
@@ -29,4 +29,4 @@ updates:
       # Run every Saturday at 00:00.
       cronjob: '0 0 * * 6'
     cooldown:
-      default-days: 5
+      default-days: 7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ ignoredBuiltDependencies:
   - sharp
   - unix-dgram
 
-minimumReleaseAge: 7200
+minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - flatted
 


### PR DESCRIPTION
Increase the `cooldown.default-days` from 5 to 7 days in dependabot.yml and increase the `minReleaseAge` from 7200 to 10080 minutes (7 days) in pnpm-workspace.yaml.