### PR TITLE
chore: un-override flatted

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   lodash: ^4.17.23
-  flatted: ^3.4.2
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,10 @@ ignoredBuiltDependencies:
 
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
-  - flatted
 
 overrides:
   # added 20260131
   'lodash': ^4.17.23
-  # added 20260322
-  'flatted': ^3.4.2
 
 saveExact: true
 


### PR DESCRIPTION
No longer needed to override flatted.