### PR TITLE
chore: update pnpm to v11.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lab.probablerobot.net",
   "private": true,
-  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,15 +1,14 @@
 packages:
   - functions/*
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - netlify-cli
-  - sharp
-  - unix-dgram
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  netlify-cli: false
+  sharp: false
+  unix-dgram: false
 
 minimumReleaseAge: 10080 # 7 days in minutes
-minimumReleaseAgeExclude:
 
 overrides:
   # added 20260131


### PR DESCRIPTION
- Update package.json#packageManager.
- Consolidate build-dependency settings into `allowBuilds` according to how pnpm v11 does this. This gets rid of `ignoredBuiltDependencies`.