### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'cron'
-      # Run every Saturday at 00:00.
-      cronjob: '0 0 * * 6'
+      # Run every Sunday at 00:00.
+      cronjob: '0 0 * * 7'
     cooldown:
       default-days: 7


### PR DESCRIPTION
Update npm dependencies and github-actions dependencies on different days to avoid having to unnecessarily rebase their PRs.